### PR TITLE
continuing when UnsupportedMimeType exception is encountered

### DIFF
--- a/src/main/java/com/frogfront/webcrawler/DomainWebCrawler.java
+++ b/src/main/java/com/frogfront/webcrawler/DomainWebCrawler.java
@@ -65,8 +65,9 @@ public class DomainWebCrawler implements WebCrawler {
 				try {
 					connectionResponse = Jsoup.connect(nextUrl).method(Connection.Method.GET).execute();
 				} catch (UnsupportedMimeTypeException e) {
-					log.error("UnsupportedMimeTypeException on url " + nextUrl, e);
-					throw new IOException(e);
+					urls.remove(nextUrl);
+					urlIt = urls.iterator();
+					continue;
 				}
 				try {
 					String lastModified = connectionResponse.headers("Last-Modified").get(0);

--- a/src/test/java/com/frogfront/webcrawler/WebCrawlerTest.java
+++ b/src/test/java/com/frogfront/webcrawler/WebCrawlerTest.java
@@ -11,7 +11,9 @@ import java.net.URL;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
+import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.nodes.Document;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -27,6 +29,7 @@ import com.frogfront.webcrawler.api.WebCrawler;
 @PrepareForTest({ Jsoup.class })
 
 public class WebCrawlerTest {
+	
 
 	@Test
 	public void testWebCrwaler() throws IOException {
@@ -176,6 +179,62 @@ public class WebCrawlerTest {
 		String expected = "";
 		String actual = new String(actualOs.toByteArray());
 
+		assertThat(actual, equalTo(expected));
+		actualOs.close();
+	}
+	
+	@Test
+	public void UnsupportedMimeTypeExceptionTest() throws IOException {
+		Document doc1 = Jsoup.parse(this.getClass().getResourceAsStream("/index.html"), null,
+				"http://example.com/index.html");
+		Document doc2 = Jsoup.parse(this.getClass().getResourceAsStream("/foo.html"), null,
+				"http://example.com/foo.html");
+		Document doc3 = Jsoup.parse(this.getClass().getResourceAsStream("/UnsupportedMimeType.html"), null,
+				"http://example.com/bar.html");
+
+		Connection connection1 = Mockito.mock(Connection.class);
+		Connection connection2 = Mockito.mock(Connection.class);
+		Connection connection3 = Mockito.mock(Connection.class);
+		Connection connectionUnsupported = Mockito.mock(Connection.class);
+		Connection.Response response1 = Mockito.mock(Connection.Response.class);
+		Connection.Response response2 = Mockito.mock(Connection.Response.class);
+		Connection.Response response3 = Mockito.mock(Connection.Response.class);
+
+		PowerMockito.mockStatic(Jsoup.class);
+
+		Mockito.when(Jsoup.connect("http://example.com")).thenReturn(connection1);
+		Mockito.when(connection1.method(Connection.Method.GET)).thenReturn(connection1);
+		Mockito.when(connection1.execute()).thenReturn(response1);
+		Mockito.when(response1.parse()).thenReturn(doc1);
+
+		Mockito.when(Jsoup.connect("http://example.com/foo.html")).thenReturn(connection2);
+		Mockito.when(connection2.method(Connection.Method.GET)).thenReturn(connection2);
+		Mockito.when(connection2.execute()).thenReturn(response2);
+		Mockito.when(response2.parse()).thenReturn(doc2);
+
+		Mockito.when(Jsoup.connect("http://example.com/bar.html")).thenReturn(connection3);
+		Mockito.when(connection3.method(Connection.Method.GET)).thenReturn(connection3);
+		Mockito.when(connection3.execute()).thenReturn(response3);
+		Mockito.when(response3.parse()).thenReturn(doc3);
+		
+		Mockito.when(Jsoup.connect("http://example.com/image.png")).thenReturn(connectionUnsupported);
+		Mockito.when(connectionUnsupported.method(Connection.Method.GET)).thenReturn(connectionUnsupported);
+		Mockito.when(connectionUnsupported.execute()).thenThrow(new UnsupportedMimeTypeException("","",""));
+
+		ByteArrayOutputStream actualOs = new ByteArrayOutputStream();
+		ReportingLocationProvider locationProvider = new ReportingLocationProvider(actualOs);
+		WebCrawler webCrawler = new DomainWebCrawler();
+		
+		InputStream robotsStream = this.getClass().getResourceAsStream("/robots.txt");
+		RobotsTxtParser robotsParser = new RobotsTxtParser(new URL("http://example.com"),robotsStream);
+		
+		webCrawler.useRobotstxt(robotsParser);
+		webCrawler.useLocationProvider(locationProvider);
+		webCrawler.crawlUrl(new URL("http://example.com"));
+
+		String expected = IOUtils.toString(this.getClass().getResourceAsStream("/unsupported-out.txt"));
+		String actual = new String(actualOs.toByteArray());
+		actualOs.close();
 		assertThat(actual, equalTo(expected));
 		actualOs.close();
 	}

--- a/src/test/resources/UnsupportedMimeType.html
+++ b/src/test/resources/UnsupportedMimeType.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link href="scr/foo.js">
+<meta charset="UTF-8">
+<title>Home</title>
+</head>
+<body>
+<a href="/">Home</a><a href="foo.html">Foo</a><a href="bar.html">Bar</a>
+<img alt="" src="img/foo.jpg">
+<a href="image.png"><img src="image.png" /></a>
+</body>
+</html>

--- a/src/test/resources/unsupported-out.txt
+++ b/src/test/resources/unsupported-out.txt
@@ -1,0 +1,31 @@
+
+BASE URL http://example.com
+Parameters
+
+	DOMAIN
+		http://example.com/bar.html
+		http://example.com/
+		http://example.com/foo.html
+	DOMAIN_IMAGE
+		http://example.com/img/foo.jpg
+
+BASE URL http://example.com/foo.html
+Parameters
+
+	DOMAIN
+		http://example.com/bar.html
+		http://example.com/
+		http://example.com/foo.html
+	DOMAIN_IMAGE
+		http://example.com/img/foo.jpg
+
+BASE URL http://example.com/bar.html
+Parameters
+
+	DOMAIN
+		http://example.com/bar.html
+		http://example.com/
+		http://example.com/foo.html
+	DOMAIN_IMAGE
+		http://example.com/image.png
+		http://example.com/img/foo.jpg


### PR DESCRIPTION
Address issue https://github.com/Frog-Front/web-crawler/issues/3 where the current functionality terminates the crawling process when an UnsupportedMimeType is encountered.

Currently supporting
GIVEN when crawling a URL
WHEN a non text based based URL is encountered
THEN an UnsupportedMimeType is Thrown
IF an UnsupportedMimeType is Thrown
THEN crawling process is terminated

Updates remove the previous functionality of throwing an IOException. To removing the URL from the crawling list and continuing on to the next.

Updated
GIVEN when crawling a URL
WHEN a non text based based URL is encountered
THEN an UnsupportedMimeType is Thrown
IF an UnsupportedMimeType is Thrown
THEN crawling process continues
