### PR TITLE
Http errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ BASE URL http://example.com
 Parameters
 LAST_MODIFIED::
 
+HTTP STATUS 200
+
 	DOMAIN
 		http://example.com/foo
 	DOMAIN_IMAGE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-applicationVersion=0.0.2
+applicationVersion=0.1.0
 jsoupVersion=1.13.1

--- a/src/main/java/com/frogfront/webcrawler/ReportingLocationProvider.java
+++ b/src/main/java/com/frogfront/webcrawler/ReportingLocationProvider.java
@@ -33,6 +33,7 @@ public class ReportingLocationProvider implements LocationProvider {
 		@Override
 		public LocationSource useLocaton(String locUrl, String status) {
 			locationUrl = locUrl;
+			httpStatus = status;
 			return this;
 		}
 

--- a/src/main/java/com/frogfront/webcrawler/ReportingLocationProvider.java
+++ b/src/main/java/com/frogfront/webcrawler/ReportingLocationProvider.java
@@ -18,6 +18,7 @@ import com.frogfront.webcrawler.api.LocationSource.ParameterNames;
 public class ReportingLocationProvider implements LocationProvider {
 
 	private String locationUrl;
+	private String httpStatus;
 	private Map<ParameterNames, String> parameters;
 	private Map<String, LocationType> embededURLs;
 
@@ -30,7 +31,7 @@ public class ReportingLocationProvider implements LocationProvider {
 	private LocationSource locationSource = new LocationSource() {
 
 		@Override
-		public LocationSource useLocaton(String locUrl) {
+		public LocationSource useLocaton(String locUrl, String status) {
 			locationUrl = locUrl;
 			return this;
 		}
@@ -62,6 +63,7 @@ public class ReportingLocationProvider implements LocationProvider {
 
 		StringBuilder strBuilder = new StringBuilder();
 		strBuilder.append("\nBASE URL " + this.locationUrl + "\n");
+		strBuilder.append("\nHTTP STATUS " + this.httpStatus + "\n");
 		strBuilder.append("Parameters\n");
 		this.parameters.forEach((k, v) -> {
 			if (k != (LocationSource.ParameterNames.RAW)) {

--- a/src/main/java/com/frogfront/webcrawler/api/LocationSource.java
+++ b/src/main/java/com/frogfront/webcrawler/api/LocationSource.java
@@ -5,14 +5,14 @@ import java.util.Map;
 public interface LocationSource {
 
 	public static enum LocationType {
-		DOMAIN, EXTERNAL, DOMAIN_IMAGE, EXTERNAL_IMAGE
+		DOMAIN, EXTERNAL, DOMAIN_IMAGE, EXTERNAL_IMAGE, ERROR
 	};
 
 	public static enum ParameterNames {
 		LAST_MODIFIED, RAW
 	}
 
-	public LocationSource useLocaton(String locationUrl);
+	public LocationSource useLocaton(String locationUrl, String Status);
 
 	public LocationSource useParameters(Map<ParameterNames, String> parameters);
 

--- a/src/main/java/com/frogfront/webcrawler/api/LocationSource.java
+++ b/src/main/java/com/frogfront/webcrawler/api/LocationSource.java
@@ -5,7 +5,7 @@ import java.util.Map;
 public interface LocationSource {
 
 	public static enum LocationType {
-		DOMAIN, EXTERNAL, DOMAIN_IMAGE, EXTERNAL_IMAGE, ERROR
+		DOMAIN, EXTERNAL, DOMAIN_IMAGE, EXTERNAL_IMAGE
 	};
 
 	public static enum ParameterNames {

--- a/src/test/java/com/frogfront/webcrawler/LocationProviderStub.java
+++ b/src/test/java/com/frogfront/webcrawler/LocationProviderStub.java
@@ -1,0 +1,48 @@
+package com.frogfront.webcrawler;
+
+import java.util.Map;
+
+import com.frogfront.webcrawler.api.LocationProvider;
+import com.frogfront.webcrawler.api.LocationSource;
+import com.frogfront.webcrawler.api.LocationSource.LocationType;
+import com.frogfront.webcrawler.api.LocationSource.ParameterNames;
+
+public class LocationProviderStub implements LocationProvider {
+
+	String location;
+	String httpStatus;
+	Map<ParameterNames, String> parameters;
+	Map<String, LocationType> embededURls;
+
+	@Override
+	public LocationSource newLocationSource() {
+		return new LocationSource(){
+
+			@Override
+			public LocationSource useLocaton(String locUrl, String status) {
+				location = locUrl;
+				httpStatus = status;
+				return this;
+			}
+
+			@Override
+			public LocationSource useParameters(Map<ParameterNames, String> params) {
+				parameters = params;
+				return this;
+			}
+
+			@Override
+			public LocationSource useEmbededUrls(Map<String, LocationType> EMURLs) {
+				embededURls = EMURLs;
+				return this;
+			}
+		};
+	}
+
+	@Override
+	public void execute() {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/test/java/com/frogfront/webcrawler/ReportingLocationProviderTest.java
+++ b/src/test/java/com/frogfront/webcrawler/ReportingLocationProviderTest.java
@@ -30,7 +30,7 @@ public class ReportingLocationProviderTest {
 		locations.put("http://google.com/foo", LocationSource.LocationType.EXTERNAL);
 		locations.put("http://google.com/foo.png", LocationSource.LocationType.EXTERNAL_IMAGE);
 
-		rlp.newLocationSource().useParameters(params).useLocaton("http://example.com").useEmbededUrls(locations);
+		rlp.newLocationSource().useParameters(params).useLocaton("http://example.com","200").useEmbededUrls(locations);
 		rlp.execute();
 
 		String expected = IOUtils.toString(this.getClass().getResourceAsStream("/rlp-out.txt"));

--- a/src/test/java/com/frogfront/webcrawler/ReportingLocationProviderTest.java
+++ b/src/test/java/com/frogfront/webcrawler/ReportingLocationProviderTest.java
@@ -38,5 +38,5 @@ public class ReportingLocationProviderTest {
 		assertThat(actual, equalTo(expected));
 		
 	}
-
+	
 }

--- a/src/test/resources/crawler-out.txt
+++ b/src/test/resources/crawler-out.txt
@@ -1,5 +1,7 @@
 
 BASE URL http://example.com
+
+HTTP STATUS null
 Parameters
 
 	DOMAIN
@@ -10,6 +12,8 @@ Parameters
 		http://example.com/img/foo.jpg
 
 BASE URL http://example.com/foo.html
+
+HTTP STATUS null
 Parameters
 
 	DOMAIN
@@ -20,6 +24,8 @@ Parameters
 		http://example.com/img/foo.jpg
 
 BASE URL http://example.com/bar.html
+
+HTTP STATUS null
 Parameters
 
 	DOMAIN

--- a/src/test/resources/crawler-out.txt
+++ b/src/test/resources/crawler-out.txt
@@ -1,7 +1,7 @@
 
 BASE URL http://example.com
 
-HTTP STATUS null
+HTTP STATUS 0
 Parameters
 
 	DOMAIN
@@ -13,7 +13,7 @@ Parameters
 
 BASE URL http://example.com/foo.html
 
-HTTP STATUS null
+HTTP STATUS 0
 Parameters
 
 	DOMAIN
@@ -25,7 +25,7 @@ Parameters
 
 BASE URL http://example.com/bar.html
 
-HTTP STATUS null
+HTTP STATUS 0
 Parameters
 
 	DOMAIN

--- a/src/test/resources/rlp-out.txt
+++ b/src/test/resources/rlp-out.txt
@@ -1,7 +1,7 @@
 
 BASE URL http://example.com
 
-HTTP STATUS null
+HTTP STATUS 200
 Parameters
 LAST_MODIFIED::foo
 

--- a/src/test/resources/rlp-out.txt
+++ b/src/test/resources/rlp-out.txt
@@ -1,5 +1,7 @@
 
 BASE URL http://example.com
+
+HTTP STATUS null
 Parameters
 LAST_MODIFIED::foo
 

--- a/src/test/resources/unsupported-out.txt
+++ b/src/test/resources/unsupported-out.txt
@@ -1,5 +1,7 @@
 
 BASE URL http://example.com
+
+HTTP STATUS null
 Parameters
 
 	DOMAIN
@@ -10,6 +12,8 @@ Parameters
 		http://example.com/img/foo.jpg
 
 BASE URL http://example.com/foo.html
+
+HTTP STATUS null
 Parameters
 
 	DOMAIN
@@ -20,6 +24,8 @@ Parameters
 		http://example.com/img/foo.jpg
 
 BASE URL http://example.com/bar.html
+
+HTTP STATUS null
 Parameters
 
 	DOMAIN

--- a/src/test/resources/unsupported-out.txt
+++ b/src/test/resources/unsupported-out.txt
@@ -1,7 +1,7 @@
 
 BASE URL http://example.com
 
-HTTP STATUS null
+HTTP STATUS 0
 Parameters
 
 	DOMAIN
@@ -13,7 +13,7 @@ Parameters
 
 BASE URL http://example.com/foo.html
 
-HTTP STATUS null
+HTTP STATUS 0
 Parameters
 
 	DOMAIN
@@ -25,7 +25,7 @@ Parameters
 
 BASE URL http://example.com/bar.html
 
-HTTP STATUS null
+HTTP STATUS 0
 Parameters
 
 	DOMAIN


### PR DESCRIPTION
Reporting when a `HttpStatusException' is thrown and adding it to both cases if failed or success. 

A failed request will now be reported as follows:

```
BASE URL https://example.com/missingpage.html
HTTP STATUS 404
Parameters
```

A `LocationProviderStub` was added to so full mock are unnecessary for some tests.

The currently crawled URL was added to the crawled set whenever a requested URL throws an Exception. This will mitigate future attempts if the bad url is discovered on other pages.